### PR TITLE
don't require -latlon to be set

### DIFF
--- a/main.go
+++ b/main.go
@@ -73,6 +73,10 @@ func main() {
 }
 
 func parseLatlon(v string) (string, string, error) {
+	if v == "" {
+		return "", "", nil
+	}
+
 	comma := strings.IndexRune(v, ',')
 	if comma < 0 {
 		return "", "", errors.New("want format: lat,lon")


### PR DESCRIPTION
Without this patch, you have to provide `-latlon ,` to successfully
convey absence of latlon info.
